### PR TITLE
Targeted Bazel builds with R2 remote cache

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,5 @@
 name: Verify Proposal Build
-run-name: "Verify Proposal #${{ inputs.proposal_id }} (${{ inputs.runner || 'ubuntu-latest' }})"
+run-name: "Verify Proposal #${{ inputs.proposal_id }}"
 
 on:
   workflow_dispatch:
@@ -8,15 +8,10 @@ on:
         description: 'NNS Proposal ID to verify'
         required: true
         type: string
-      runner:
-        description: 'GitHub Actions runner label'
-        required: false
-        type: string
-        default: 'ubuntu-latest'
 
 jobs:
   verify:
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/dfinity/ic-build:latest
       options: --privileged -v /var/run/docker.sock:/var/run/docker.sock

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,6 +72,9 @@ jobs:
           # Tell build-ic.sh we're already in the correct container (ic-build)
           # This skips nested container creation which fails on cgroups and disk space
           DFINITY_CONTAINER: "true"
+          # Cloudflare R2-backed Bazel remote cache
+          BAZEL_REMOTE_CACHE_URL: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
+          BAZEL_REMOTE_CACHE_TOKEN: ${{ secrets.BAZEL_REMOTE_CACHE_TOKEN }}
 
       - name: Install didc (for arg hash verification)
         if: steps.fetch.outputs.skipped != 'true'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,5 @@
 name: Verify Proposal Build
-run-name: "Verify Proposal #${{ inputs.proposal_id }}"
+run-name: "Verify Proposal #${{ inputs.proposal_id }} (${{ inputs.runner || 'ubuntu-latest' }})"
 
 on:
   workflow_dispatch:
@@ -8,10 +8,15 @@ on:
         description: 'NNS Proposal ID to verify'
         required: true
         type: string
+      runner:
+        description: 'GitHub Actions runner label'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     container:
       image: ghcr.io/dfinity/ic-build:latest
       options: --privileged -v /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -99,7 +99,7 @@ if [ -n "$BAZEL_TARGET" ]; then
     echo ""
     echo "=== TARGETED Bazel build: $BAZEL_TARGET ==="
 
-    BAZEL_CMD="bazel build --config=stamped $BAZEL_TARGET"
+    BAZEL_CMD="bazel build --config=local --config=stamped $BAZEL_TARGET"
 
     if setup_builder_user; then
         echo ">>> Executing (as builder): $BAZEL_CMD"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -120,7 +120,7 @@ CACHEEOF
 
         # Skip --config=local (which disables remote cache) and override DFINITY's
         # internal cache with ours via the additional bazelrc file
-        BAZEL_CMD="bazel --bazelrc=$CACHE_BAZELRC build --config=stamped $BAZEL_TARGET"
+        BAZEL_CMD="bazel --bazelrc=$CACHE_BAZELRC build --announce_rc --config=stamped $BAZEL_TARGET"
     else
         echo "No remote cache configured (BAZEL_REMOTE_CACHE_URL=${BAZEL_REMOTE_CACHE_URL:-unset}, BAZEL_REMOTE_CACHE_TOKEN=${BAZEL_REMOTE_CACHE_TOKEN:+set})"
         # No cache configured; use --config=local to disable DFINITY's unreachable internal cache

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,7 +111,7 @@ CACHEEOF
         chmod 644 "$CACHE_BAZELRC"
         # Skip --config=local (which disables remote cache) and override DFINITY's
         # internal cache with ours via the additional bazelrc file
-        BAZEL_CMD="bazel build --bazelrc=$CACHE_BAZELRC --config=stamped $BAZEL_TARGET"
+        BAZEL_CMD="bazel --bazelrc=$CACHE_BAZELRC build --config=stamped $BAZEL_TARGET"
     else
         # No cache configured; use --config=local to disable DFINITY's unreachable internal cache
         BAZEL_CMD="bazel build --config=local --config=stamped $BAZEL_TARGET"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,8 +18,10 @@ fi
 COMMIT_HASH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('build-steps.json')).commitHash)")
 REPO_URL=$(node -e "console.log(JSON.parse(require('fs').readFileSync('build-steps.json')).repoUrl)")
 WASM_OUTPUT_PATH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('build-steps.json')).wasmOutputPath)")
+WASM_FILENAME=$(basename "$WASM_OUTPUT_PATH")
 
 echo "Repository: $REPO_URL"
+echo "WASM filename: $WASM_FILENAME"
 echo "Commit hash: $COMMIT_HASH"
 echo "Expected WASM output: $WASM_OUTPUT_PATH"
 
@@ -39,6 +41,30 @@ echo "Fetching commit $COMMIT_HASH..."
 git fetch --depth 1 origin "$COMMIT_HASH"
 git checkout "$COMMIT_HASH"
 
+# Detect IC monorepo and resolve Bazel target
+IS_IC_MONOREPO=false
+BAZEL_TARGET=""
+
+if [[ "$REPO_URL" == *"github.com/dfinity/ic"* ]]; then
+    IS_IC_MONOREPO=true
+    echo ""
+    echo "=== Detected IC monorepo - attempting targeted Bazel build ==="
+
+    BUILD_BAZEL="publish/canisters/BUILD.bazel"
+    if [ -f "$BUILD_BAZEL" ]; then
+        # Parse CANISTERS dict: "governance-canister.wasm.gz": "//rs/nns/governance:governance-canister"
+        BAZEL_TARGET=$(grep -E "\"$WASM_FILENAME\"\s*:" "$BUILD_BAZEL" | \
+            sed -E 's/.*"[^"]+"\s*:\s*"([^"]+)".*/\1/' | \
+            head -1) || true
+
+        if [ -n "$BAZEL_TARGET" ]; then
+            echo "Found Bazel target: $BAZEL_TARGET"
+        else
+            echo "Could not find target for $WASM_FILENAME, will use full build"
+        fi
+    fi
+fi
+
 # Patch any scripts that force DOCKER_BUILDKIT=1
 echo "Patching docker-build scripts to disable BuildKit..."
 find . -name "docker-build" -type f -exec sed -i 's/export DOCKER_BUILDKIT=1/export DOCKER_BUILDKIT=0/g' {} \;
@@ -46,61 +72,89 @@ find . -name "docker-build" -type f -exec sed -i 's/export DOCKER_BUILDKIT=1/exp
 echo ""
 echo "=== Running build steps ==="
 
-# Create marker file to prevent nested container spawning
-# The IC build scripts check for /home/ubuntu/.ic-build-container to detect
-# if they're already running inside the ic-build container
-mkdir -p /home/ubuntu
-touch /home/ubuntu/.ic-build-container
-echo "Created /home/ubuntu/.ic-build-container marker file"
+# Helper function to setup builder user (bazel's rules_python requires non-root)
+setup_builder_user() {
+    if [ "$(id -u)" = "0" ]; then
+        echo "Running as root, creating build user for bazel..."
+        useradd -m -s /bin/bash builder 2>/dev/null || true
+        chown -R builder:builder .
+        mkdir -p /home/builder/.cache
+        chown -R builder:builder /home/builder
+        if [ -S /var/run/docker.sock ]; then
+            echo "Granting builder user access to Docker socket..."
+            DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
+            echo "Docker socket GID: $DOCKER_SOCKET_GID"
+            groupadd -g "$DOCKER_SOCKET_GID" -f docker 2>/dev/null || true
+            usermod -aG "$DOCKER_SOCKET_GID" builder 2>/dev/null || true
+        fi
+        return 0
+    fi
+    return 1
+}
 
-# Read build steps
-STEPS=$(node -e "JSON.parse(require('fs').readFileSync('../build-steps.json')).steps.forEach(s => console.log(s))")
+TARGETED_BUILD_SUCCESS=false
 
-# If running as root, create a non-root user and run bazel as that user
-# (rules_python requires non-root for hermetic Python)
-if [ "$(id -u)" = "0" ]; then
-    echo "Running as root, creating build user for bazel..."
-    useradd -m -s /bin/bash builder 2>/dev/null || true
+# Try targeted Bazel build if we have a target
+if [ -n "$BAZEL_TARGET" ]; then
+    echo ""
+    echo "=== TARGETED Bazel build: $BAZEL_TARGET ==="
 
-    # Give builder ownership of the ic directory
-    chown -R builder:builder .
+    BAZEL_CMD="bazel build --config=stamped $BAZEL_TARGET"
 
-    # Create bazel cache directory for builder
-    mkdir -p /home/builder/.cache
-    chown -R builder:builder /home/builder
-
-    # Grant builder access to Docker socket if it exists
-    if [ -S /var/run/docker.sock ]; then
-        echo "Granting builder user access to Docker socket..."
-        # Get the GID of the Docker socket
-        DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
-        echo "Docker socket GID: $DOCKER_SOCKET_GID"
-
-        # Add builder user to the Docker socket's group
-        groupadd -g "$DOCKER_SOCKET_GID" -f docker 2>/dev/null || true
-        usermod -aG "$DOCKER_SOCKET_GID" builder 2>/dev/null || true
+    if setup_builder_user; then
+        echo ">>> Executing (as builder): $BAZEL_CMD"
+        if su - builder -c "cd $(pwd) && $BAZEL_CMD"; then
+            TARGETED_BUILD_SUCCESS=true
+        fi
+    else
+        echo ">>> Executing: $BAZEL_CMD"
+        if eval "$BAZEL_CMD"; then
+            TARGETED_BUILD_SUCCESS=true
+        fi
     fi
 
-    # Execute each step as builder user
-    while IFS= read -r step; do
-        if [ -n "$step" ]; then
-            echo ""
-            echo ">>> Executing (as builder): $step"
-            su - builder -c "cd $(pwd) && export DOCKER_BUILDKIT=0 DFINITY_CONTAINER=${DFINITY_CONTAINER:-} && $step" || {
-                echo "Warning: Build command returned non-zero exit code: $?"
-                echo "Checking if build artifacts were produced anyway..."
-            }
-        fi
-    done <<< "$STEPS"
-else
-    # Execute each step normally
-    while IFS= read -r step; do
-        if [ -n "$step" ]; then
-            echo ""
-            echo ">>> Executing: $step"
-            export DOCKER_BUILDKIT=0 DFINITY_CONTAINER=${DFINITY_CONTAINER:-} && eval "$step"
-        fi
-    done <<< "$STEPS"
+    if [ "$TARGETED_BUILD_SUCCESS" = false ]; then
+        echo "Targeted build failed, falling back to full build..."
+    fi
+fi
+
+# Fallback to full build
+if [ "$TARGETED_BUILD_SUCCESS" = false ]; then
+    echo ""
+    echo "=== Running full build ==="
+
+    # Create marker file to prevent nested container spawning
+    # The IC build scripts check for /home/ubuntu/.ic-build-container to detect
+    # if they're already running inside the ic-build container
+    mkdir -p /home/ubuntu
+    touch /home/ubuntu/.ic-build-container
+    echo "Created /home/ubuntu/.ic-build-container marker file"
+
+    # Read build steps
+    STEPS=$(node -e "JSON.parse(require('fs').readFileSync('../build-steps.json')).steps.forEach(s => console.log(s))")
+
+    if setup_builder_user; then
+        # Execute each step as builder user
+        while IFS= read -r step; do
+            if [ -n "$step" ]; then
+                echo ""
+                echo ">>> Executing (as builder): $step"
+                su - builder -c "cd $(pwd) && export DOCKER_BUILDKIT=0 DFINITY_CONTAINER=${DFINITY_CONTAINER:-} && $step" || {
+                    echo "Warning: Build command returned non-zero exit code: $?"
+                    echo "Checking if build artifacts were produced anyway..."
+                }
+            fi
+        done <<< "$STEPS"
+    else
+        # Execute each step normally
+        while IFS= read -r step; do
+            if [ -n "$step" ]; then
+                echo ""
+                echo ">>> Executing: $step"
+                export DOCKER_BUILDKIT=0 DFINITY_CONTAINER=${DFINITY_CONTAINER:-} && eval "$step"
+            fi
+        done <<< "$STEPS"
+    fi
 fi
 
 echo ""
@@ -109,14 +163,39 @@ echo "=== Build complete ==="
 # Copy output WASM to known location
 mkdir -p ../output
 
-if [ -f "$WASM_OUTPUT_PATH" ]; then
-    cp "$WASM_OUTPUT_PATH" ../output/canister.wasm
-    echo "Copied WASM to ../output/canister.wasm"
+if [ "$TARGETED_BUILD_SUCCESS" = true ]; then
+    # Derive bazel-bin path: //rs/nns/governance:governance-canister -> bazel-bin/rs/nns/governance/governance-canister.wasm.gz
+    BAZEL_PACKAGE=$(echo "$BAZEL_TARGET" | sed 's|^//||' | sed 's|:.*||')
+    BAZEL_TARGET_NAME=$(echo "$BAZEL_TARGET" | sed 's|.*:||')
+    BAZEL_OUTPUT="bazel-bin/$BAZEL_PACKAGE/${BAZEL_TARGET_NAME}.wasm.gz"
+
+    echo "Looking for Bazel output at: $BAZEL_OUTPUT"
+
+    if [ -f "$BAZEL_OUTPUT" ]; then
+        cp "$BAZEL_OUTPUT" ../output/canister.wasm
+        echo "Copied Bazel output to ../output/canister.wasm"
+    else
+        echo "Expected Bazel output not found, searching bazel-bin for $WASM_FILENAME..."
+        FOUND=$(find bazel-bin -name "$WASM_FILENAME" -type f 2>/dev/null | head -1)
+        if [ -n "$FOUND" ]; then
+            cp "$FOUND" ../output/canister.wasm
+            echo "Copied $FOUND to ../output/canister.wasm"
+        else
+            echo "Error: Could not find $WASM_FILENAME in bazel-bin"
+            exit 1
+        fi
+    fi
 else
-    echo "Warning: Expected WASM not found at $WASM_OUTPUT_PATH"
-    echo "Searching for .wasm files..."
-    find . -name "*.wasm" -type f 2>/dev/null | head -20
-    exit 1
+    # Original full build output path
+    if [ -f "$WASM_OUTPUT_PATH" ]; then
+        cp "$WASM_OUTPUT_PATH" ../output/canister.wasm
+        echo "Copied WASM to ../output/canister.wasm"
+    else
+        echo "Warning: Expected WASM not found at $WASM_OUTPUT_PATH"
+        echo "Searching for .wasm files..."
+        find . -name "*.wasm" -type f 2>/dev/null | head -20
+        exit 1
+    fi
 fi
 
 cd ..

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -100,13 +100,7 @@ if [ -n "$BAZEL_TARGET" ]; then
     echo "=== TARGETED Bazel build: $BAZEL_TARGET ==="
 
     if [ -n "${BAZEL_REMOTE_CACHE_URL:-}" ] && [ -n "${BAZEL_REMOTE_CACHE_TOKEN:-}" ]; then
-        echo "Remote cache: $BAZEL_REMOTE_CACHE_URL"
-
-        # Test cache connectivity
-        CACHE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $BAZEL_REMOTE_CACHE_TOKEN" "$BAZEL_REMOTE_CACHE_URL/" 2>&1) || true
-        echo "Cache connectivity test: HTTP $CACHE_STATUS"
-
-        # Write cache config to file; quote the header flag to protect the space in "Bearer TOKEN"
+        echo "Remote cache enabled"
         CACHE_BAZELRC="/tmp/remote-cache.bazelrc"
         cat > "$CACHE_BAZELRC" << CACHEEOF
 build --remote_cache=$BAZEL_REMOTE_CACHE_URL
@@ -116,15 +110,8 @@ build --experimental_remote_downloader=
 build --experimental_remote_cache_compression=false
 CACHEEOF
         chmod 644 "$CACHE_BAZELRC"
-
-        echo "Cache bazelrc contents:"
-        cat "$CACHE_BAZELRC"
-
-        # Skip --config=local (which disables remote cache) and override DFINITY's
-        # internal cache with ours via the additional bazelrc file
-        BAZEL_CMD="bazel --bazelrc=$CACHE_BAZELRC build --announce_rc --config=stamped $BAZEL_TARGET"
+        BAZEL_CMD="bazel --bazelrc=$CACHE_BAZELRC build --config=stamped $BAZEL_TARGET"
     else
-        echo "No remote cache configured (BAZEL_REMOTE_CACHE_URL=${BAZEL_REMOTE_CACHE_URL:-unset}, BAZEL_REMOTE_CACHE_TOKEN=${BAZEL_REMOTE_CACHE_TOKEN:+set})"
         # No cache configured; use --config=local to disable DFINITY's unreachable internal cache
         BAZEL_CMD="bazel build --config=local --config=stamped $BAZEL_TARGET"
     fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,6 +112,8 @@ if [ -n "$BAZEL_TARGET" ]; then
 build --remote_cache=$BAZEL_REMOTE_CACHE_URL
 build "--remote_header=Authorization=Bearer $BAZEL_REMOTE_CACHE_TOKEN"
 build --remote_upload_local_results=true
+build --experimental_remote_downloader=
+build --experimental_remote_cache_compression=false
 CACHEEOF
         chmod 644 "$CACHE_BAZELRC"
 


### PR DESCRIPTION
## Summary
- Detect IC monorepo proposals and resolve the specific Bazel target from `publish/canisters/BUILD.bazel`
- Run `bazel build` for just the needed canister instead of all ~45 via `build-ic.sh -c`
- Use a Cloudflare R2-backed remote cache to skip recompilation of shared dependencies across runs
- Fall back to the original full build if target lookup or Bazel build fails

## Results

| Run | Time | Improvement |
|-----|------|-------------|
| Main (full build, all canisters) | 29m42s | — |
| Targeted, no cache | 20m21s | -31% |
| Targeted + R2 cache (cold) | 19m32s | -34% |
| **Targeted + R2 cache (warm)** | **7m33s** | **-75%** |

## How it works

**Targeted build:** Parses the `CANISTERS` dict in the IC repo's `publish/canisters/BUILD.bazel` to find the Bazel target for the specific canister WASM filename, then runs `bazel build --config=stamped <target>`.

**Remote cache:** A Cloudflare Worker (`bazel-remote-cache`) backed by R2 implements Bazel's HTTP remote cache protocol. Configured via `BAZEL_REMOTE_CACHE_URL` and `BAZEL_REMOTE_CACHE_TOKEN` secrets. Shared Rust dependencies (~80% of build actions) are cached across runs.

**Fallback safety:**
- Only activates for `github.com/dfinity/ic` URLs
- Falls back to full build if target lookup fails
- Falls back to full build if Bazel build fails
- Non-IC repos use original flow unchanged

## Test plan
- [x] Verified hash matches for proposal #140099 (governance canister) with targeted build
- [x] Verified warm-cache build completes successfully with correct hash
- [x] Verified fallback to full build works when targeted build fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)